### PR TITLE
Add the paths object is added to the generated require.config

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function(options) {
                     return [bundleOutput.itemName, bundleOutput.modules]
                 })),
                 bundleConfigCode = '\nrequire.config('
-                    + JSON.stringify({ bundles: bundleConfig }, true, 2)
+                    + JSON.stringify({ bundles: bundleConfig, paths: options.paths }, true, 2)
                     + ');\n';
             return new File({
                 path: primaryOutput.file.path,


### PR DESCRIPTION
Hey Steve, 

I recently watched you NDC presentation ("Architecting large Single Page Applications with Knockout.js") where you showed how to split up and dynamically load parts of you application. Pretty awesome stuff. Thanks.

I was playing with your yeoman generated application and tried to point a the 'jquery' require path to a cdn path e.g. my app/require.config.js looked like this -

```
var require = {
    baseUrl: ".",
    paths: {
        "bootstrap":            "bower_modules/components-bootstrap/js/bootstrap.min",
        "crossroads":           "bower_modules/crossroads/dist/crossroads.min",
        "hasher":               "bower_modules/hasher/dist/js/hasher.min",
        "jquery":               "//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min",
        "knockout":             "bower_modules/knockout/dist/knockout",
        "knockout-projections": "bower_modules/knockout-projections/dist/knockout-projections",
        "signals":              "bower_modules/js-signals/dist/signals.min",
        "text":                 "bower_modules/requirejs-text/text"
    },
     shim: {
        "bootstrap": { deps: ["jquery"] }
     }
};

```

Notice the jquery entry is now pointing to the jquery cdn. Great. Works perfectly whilst developing - run the provided gulp task and no workee. The network tab shows that the app keeps trying to load the jquery.js from the server.

Looking at the code in index.js I can see that you are writing a require.config config to the end of the file with the additional bundles.

```
require.config({
  "bundles": {
    "about-stuff": [
      "text!components/about-page/about.html"
    ]
  }
});
```

My change changes it to 

```
require.config({
  "bundles": {
    "about-stuff": [
      "text!components/about-page/about.html"
    ]
  },
  "paths": {
    "bootstrap": "bower_modules/components-bootstrap/js/bootstrap.min",
    "crossroads": "bower_modules/crossroads/dist/crossroads.min",
    "hasher": "bower_modules/hasher/dist/js/hasher.min",
    "jquery": "https://secure.liquid-contact.com/player/js/jquery-1.7.1.min",
    "knockout": "bower_modules/knockout/dist/knockout",
    "knockout-projections": "bower_modules/knockout-projections/dist/knockout-projections",
    "signals": "bower_modules/js-signals/dist/signals.min",
    "text": "bower_modules/requirejs-text/text",
    "requireLib": "bower_modules/requirejs/require"
  }
});

```

This keeps the jquery entry in the paths. Along with the others which may or may not be correct - I admit I'm not a requirejs expert.

I suppose my query is 
1. I might just be doing it wrong and there is another way to accomplish my aims?
2. Does the fix sound right? It doesn't feel 100% correct and it might break some other stuff with unintended consequences.

Anyway it would be great to get your view on it?

Thanks,

Mark
